### PR TITLE
Remove "in [[Project Zomboid]]." in item pages

### DIFF
--- a/scripts/items/item_article.py
+++ b/scripts/items/item_article.py
@@ -505,11 +505,11 @@ def create_intro(item_data, translation_data, language_code="en"):
     # Get the appropriate template
     intro_template = translation_data.get(
         "intro_template",
-        "{article} '''{lowercase_name}''' {verb} {subsequent_article} [[item]] in [[Project Zomboid]].",
+        "{article} '''{lowercase_name}''' {verb} {subsequent_article} [[item]].",
     )
     plural_template = translation_data.get(
         "plural_intro_template",
-        "'''{lowercase_name}''' {verb} {subsequent_article} [[item]]s in [[Project Zomboid]].",
+        "'''{lowercase_name}''' {verb} {subsequent_article} [[item]]s.",
     )
 
     is_plural = False


### PR DESCRIPTION
Was briefly discussed on Discord; I think it's not bringing much linking to an not-so-visited page and the first sentence should instead be improved by users. 