### PR TITLE
Space after `color:`

### DIFF
--- a/scripts/items/lists/item_list_pzwiki.py
+++ b/scripts/items/lists/item_list_pzwiki.py
@@ -41,7 +41,7 @@ def generate_table(items_data: dict):
             if id_rec:
                 content.append('|-')
             else:
-                content.append('|- title="ID missing in infobox" style="background-color: var(--background-color-warning-subtle); color:red;"')
+                content.append('|- title="ID missing in infobox" style="background-color: var(--background-color-warning-subtle); color: red;"')
                 item_id += "*"
 
             content.extend((


### PR DESCRIPTION
Change `color:red` to `color: red`, as per the preferred style guide; minor nit