### PR TITLE
Add the Wiki_page variable

### DIFF
--- a/resources/Translate/EN/Wiki_EN.json
+++ b/resources/Translate/EN/Wiki_EN.json
@@ -1,6 +1,7 @@
 {
     "Wiki_name": "Name",
     "Wiki_icon": "Icon",
+    "Wiki_page": "Page",
     "Wiki_item_id": "Item ID",
     "Wiki_fluid_id": "Fluid ID",
     "Wiki_weight": "Encumbrance",


### PR DESCRIPTION
Hopefully fixes the newly added `page` column in https://pzwiki.net/wiki/PZwiki:Item_list being lowercase, and allows for translations in the future.