### PR TITLE
Map Carography to Literature in infobox

### DIFF
--- a/scripts/utils/categories.py
+++ b/scripts/utils/categories.py
@@ -29,7 +29,7 @@ category_page_map = {
     "AnimalPartWeapon": "Animal part",
     "Appearance": "Appearance",
     "Camping": "Camping",
-    "Cartography": "Map",
+    "Cartography": "Literature",
     "Communications": "Communication",
     "Cooking": "Cooking",
     "CookingWeapon": "Cooking",


### PR DESCRIPTION
Currently clicking "Cartography" in Infobox gets to https://pzwiki.net/wiki/Map

All maps are listed in https://pzwiki.net/wiki/Literature#Cartography however so let's change the mapping